### PR TITLE
- Excludes auto generated META.json from github repo.

### DIFF
--- a/Lingua-Sentence/dist.ini
+++ b/Lingua-Sentence/dist.ini
@@ -75,5 +75,4 @@ stopword = splitter
 
 [CopyFilesFromBuild]
 copy = Makefile.PL
-copy = META.json
 copy = LICENSE


### PR DESCRIPTION
Hi @achimr 

Please review the PR.
In my humble opinion, I reckon keeping META.json in the repository is overkill. 
The other two i.e Makefile.PL and LICENSE make senss though.

Many Thanks.
Best Regards,
Mohammad S Anwar