### PR TITLE
Fixed CPAN Tester fail report.

### DIFF
--- a/Lingua-Sentence/cpanfile
+++ b/Lingua-Sentence/cpanfile
@@ -7,7 +7,7 @@ on 'runtime' => sub {
     requires 'strict';
     requires 'warnings';
     requires 'Carp';
-    requires 'File::ShareDir' => '1.02';
+    requires 'File::ShareDir' => '1.114';
     requires 'File::Spec';
     requires 'Path::Tiny';
 };


### PR DESCRIPTION
Hi @achimr 

Please review the PR.

It attempts to resolve the fail report by cpantester:
https://www.cpantesters.org/cpan/report/626fa46e-7313-11e8-952d-95cd7247484a

This issue below:

    Can't return outside a subroutine at /home/david/cpantesting/perl- 
    5.8.9/lib/site_perl/5.8.9/File/ShareDir.pm line 466.
    # Looks like your test exited with 255 before it could output anything.
    t/Lingua-Sentence.t .... 

The above issue has been patched in File::ShareDir v1.114 as Changes mentioned below:

     1.114   2018-06-21
        - be more expressive regarding to prerequisites
        - improve detection for situations where no permission test
          can be done
        - fix edge case for 5.8

Many Thanks
Best Regards,
Mohammad S Anwar